### PR TITLE
Introducing a richer set of options for covariances stored

### DIFF
--- a/neural_tangents/tests/batch_test.py
+++ b/neural_tangents/tests/batch_test.py
@@ -103,6 +103,11 @@ def _test_kernel_against_batched(cls, ker_fun, batched_ker_fun, train, test):
     cls.assertAllClose(g.var1, g_b.var1, check_dtypes=True)
     cls.assertAllClose(g.nngp, g_b.nngp, check_dtypes=True)
     cls.assertAllClose(g.ntk, g_b.ntk, check_dtypes=True)
+    cls.assertAllClose(g.is_gaussian, g_b.is_gaussian, check_dtypes=True)
+    cls.assertAllClose(
+        g.is_height_width, g_b.is_height_width, check_dtypes=True)
+    cls.assertAllClose(g.marginal, g_b.marginal, check_dtypes=True)
+    cls.assertAllClose(g.cross, g_b.cross, check_dtypes=True)
   else:
     cls.assertAllClose(g, g_b, check_dtypes=True)
 
@@ -114,6 +119,11 @@ def _test_kernel_against_batched(cls, ker_fun, batched_ker_fun, train, test):
     cls.assertAllClose(g.var2, g_b.var2, check_dtypes=True)
     cls.assertAllClose(g.nngp, g_b.nngp, check_dtypes=True)
     cls.assertAllClose(g.ntk, g_b.ntk, check_dtypes=True)
+    cls.assertAllClose(g.is_gaussian, g_b.is_gaussian, check_dtypes=True)
+    cls.assertAllClose(
+        g.is_height_width, g_b.is_height_width, check_dtypes=True)
+    cls.assertAllClose(g.marginal, g_b.marginal, check_dtypes=True)
+    cls.assertAllClose(g.cross, g_b.cross, check_dtypes=True)
   else:
     cls.assertAllClose(g, g_b, check_dtypes=True)
 
@@ -125,18 +135,18 @@ class BatchTest(jtu.JaxTestCase):
       jtu.cases_from_list(
           {
               'testcase_name':
-                  '_train_shape={}_test_shape={}_network={}_{}'.format(
-                      train, test, network, name),
+                '_train_shape={}_test_shape={}_network={}_{}'.format(
+                    train, test, network, name),
               'train_shape':
-                  train,
+                train,
               'test_shape':
-                  test,
+                test,
               'network':
-                  network,
+                network,
               'name':
-                  name,
+                name,
               'ker_fun':
-                  ker_fun
+                ker_fun
           }
           for train, test, network in zip(TRAIN_SHAPES, TEST_SHAPES, NETWORK)
           for name, ker_fun in KERNELS.items()))
@@ -159,18 +169,18 @@ class BatchTest(jtu.JaxTestCase):
       jtu.cases_from_list(
           {
               'testcase_name':
-                  '_train_shape={}_test_shape={}_network={}_{}'.format(
-                      train, test, network, name),
+                '_train_shape={}_test_shape={}_network={}_{}'.format(
+                    train, test, network, name),
               'train_shape':
-                  train,
+                train,
               'test_shape':
-                  test,
+                test,
               'network':
-                  network,
+                network,
               'name':
-                  name,
+                name,
               'ker_fun':
-                  ker_fun
+                ker_fun
           }
           for train, test, network in zip(TRAIN_SHAPES, TEST_SHAPES, NETWORK)
           for name, ker_fun in KERNELS.items()))
@@ -193,18 +203,18 @@ class BatchTest(jtu.JaxTestCase):
       jtu.cases_from_list(
           {
               'testcase_name':
-                  '_train_shape={}_test_shape={}_network={}_{}'.format(
-                      train, test, network, name),
+                '_train_shape={}_test_shape={}_network={}_{}'.format(
+                    train, test, network, name),
               'train_shape':
-                  train,
+                train,
               'test_shape':
-                  test,
+                test,
               'network':
-                  network,
+                network,
               'name':
-                  name,
+                name,
               'ker_fun':
-                  ker_fun
+                ker_fun
           }
           for train, test, network in zip(TRAIN_SHAPES, TEST_SHAPES, NETWORK)
           for name, ker_fun in KERNELS.items()
@@ -231,18 +241,18 @@ class BatchTest(jtu.JaxTestCase):
       jtu.cases_from_list(
           {
               'testcase_name':
-                  '_train_shape={}_test_shape={}_network={}_{}'.format(
-                      train, test, network, name),
+                '_train_shape={}_test_shape={}_network={}_{}'.format(
+                    train, test, network, name),
               'train_shape':
-                  train,
+                train,
               'test_shape':
-                  test,
+                test,
               'network':
-                  network,
+                network,
               'name':
-                  name,
+                name,
               'ker_fun':
-                  ker_fun
+                ker_fun
           }
           for train, test, network in zip(TRAIN_SHAPES, TEST_SHAPES, NETWORK)
           for name, ker_fun in KERNELS.items()

--- a/neural_tangents/utils/batch.py
+++ b/neural_tangents/utils/batch.py
@@ -81,7 +81,9 @@ def _flatten_kernel(k):
         _flatten_batch_dimensions(k.var2, discard_axis=0),
         _flatten_batch_dimensions(k.ntk),
         np.all(k.is_gaussian) if k.is_gaussian is not None else None,
-        np.all(k.is_height_width) if k.is_height_width  is not None else None)
+        np.all(k.is_height_width) if k.is_height_width is not None else None,
+        np.reshape(k.marginal, (-1,))[0] if k.marginal is not None else None,
+        np.reshape(k.cross, (-1,))[0] if k.cross is not None else None)
   elif isinstance(k, np.ndarray):
     return _flatten_batch_dimensions(k)
   else:
@@ -100,7 +102,9 @@ def _move_kernel_to_cpu(kernel):
         device_get(kernel.var2),
         device_get(kernel.ntk),
         kernel.is_gaussian,
-        kernel.is_height_width)
+        kernel.is_height_width,
+        kernel.marginal,
+        kernel.cross)
   else:
     return device_get(kernel)
 

--- a/neural_tangents/utils/empirical.py
+++ b/neural_tangents/utils/empirical.py
@@ -305,6 +305,7 @@ def get_ker_fun_empirical(f, compute_nngp=True, compute_ntk=True):
 
   def ker_fun(x1, x2, params):
     return Kernel(None, nngp_fun(x1, x2, params),
-                  None, ntk_fun(x1, x2, params), None, None)
+                  None, ntk_fun(x1, x2, params), None, None,
+                  None, None)
 
   return ker_fun

--- a/neural_tangents/utils/kernel.py
+++ b/neural_tangents/utils/kernel.py
@@ -12,59 +12,128 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The `Kernel` class containing NTK and and NNGP `np.ndarray`s as fields."""
+"""The `Kernel` class containing NTK and NNGP `np.ndarray`s as fields."""
 
+import aenum
 import collections
+
+
+class Marginalisation(aenum.OrderedEnum):
+  """Types of marginal distributions for which covariances can be computed.
+
+  Let k_{ij}(x, y) represent a covariance between the spatial dimensions i and j
+  for the inputs x and y (for multiple spatial dimensions, imagine i and j have
+  multiple entries). Then and instance of `Kernel` with `marginal`/`cross`:
+
+  `OVER_ALL`: (used for architectures with no spatial dimensions)
+    `var1`/`var2`: k(x, x), shape is (batch_size,)
+    `nnpg`/`ntk`: k(x, y), shape is (batch_size_1, batch_size_2)
+  `OVER_PIXELS`:
+    `var1`/`var2`: k_{ii}(x, x), shape is
+     (batch_size, spatial_dim_1, spatial_dim_2)
+    `nngp`/`ntk`: k_{ii}(x, y), shape is
+     (batch_size_1, batch_size_2, spatial_dim_1, spatial_dim_2)
+  `OVER_POINTS`:
+    `var1`/`var2`: k_{ij}(x, x), shape is
+     (batch_size, spatial_dim_1, spatial_dim_1, spatial_dim_2, spatial_dim_2)
+    `nngp`/`ntk`: not allowed; please use `NO` instead
+  `NO`:
+    `var1`/`var2`: k_{ij}(x, y), shape is
+     (batch_size, batch_size,
+      spatial_dim_1, spatial_dim_1, spatial_dim_2, spatial_dim_2)
+    `nngp`/`ntk`: k_{ij}(x, y)
+     (batch_size_1, batch_size_2,
+      spatial_dim_1, spatial_dim_1, spatial_dim_2, spatial_dim_2)
+
+  The number associated with each instance of this enum represents the relative
+  amount of information being tracked compared to the other options, i.e.,
+  the information tracked by `OVER_PIXELS` is a strict subset of that tracked
+  by `OVER_POINTS`, which itself tracks a strict subset of information
+  compared to the `NO` option. Note that this is an `OrderedEnum`
+  meaning that comparison operators `<`, `==` work as set inclusion and equality
+  (and `>`, `<=`, `>=` as would be expected given this definition).
+  """
+  NONE = None
+  OVER_ALL = 0
+  OVER_PIXELS = 1
+  OVER_POINTS = 2
+  NO = 3
 
 
 class Kernel(
     collections.namedtuple(
         'Kernel',
-        ['var1', 'nngp', 'var2', 'ntk', 'is_gaussian', 'is_height_width'])):
+        ['var1', 'nngp', 'var2', 'ntk', 'is_gaussian', 'is_height_width',
+         'marginal', 'cross'])):
   """A tuple containing information about the analytic NTK and NNGP of a model.
 
   Attributes:
     var1: variances of the first batch of inputs. A `np.ndarray` with shape
-      `[batch_size_1]`  for fully-connected networks or `[batch_size_1, height,
-      width]` for CNNs.
+      `[batch_size_1]` for fully-connected networks, or matching the one
+      specified by the `marginal` argument for CNNs with `batch_size_1` for
+      data dimension(s).
     nngp: covariance between the first and second input (NNGP). A `np.ndarray`
       of shape `[batch_size_1, batch_size_2]` for fully-connected networks, or
-      `[batch_size_1, batch_size_2, height, height, width, width]` or
-      `[batch_size_1, batch_size_2, height, width]` for CNNs if pooling is used
-      or not respectively.
-    var2: optional variances of the second batch of inputs. A `np.ndarray` with
-      shape `[batch_size_2]` for fully-connected networks or `[batch_size_2,
-      height, width]` for CNNs.
-    ntk: the neural tangent kernel (NTK). `np.ndarray` of same shape as `nngp`.
+      matching the one specifed by the `cross` argument for CNNs with
+      `[batch_size_1, batch_size_2]` for data dimensions.
+    var2: optional variances of the second batch of inputs. A `np.ndarray`
+      with shape `[batch_size_2]` for fully-connected networks or matching
+      the one  specified by the `marginal` argument for CNNs with
+      `batch_size_2` for data dimension(s).
+    ntk: the neural tangent kernel (NTK). `np.ndarray` of same shape as
+      `nngp`.
     is_gaussian: a boolean, specifying whether the output features or channels
-      of the layer / NN function (returning this `Kernel` as the `ker_fun`) are
-      i.i.d. Gaussian with covariance `nngp`, conditioned on fixed inputs to the
-      layer and i.i.d. Gaussian weights and biases of the layer. For example,
-      passing an input through a CNN layer with i.i.d. Gaussian weights and
-      biases produces i.i.d. Gaussian random variables along the channel
-      dimension, while passing an input through a nonlinearity does not.
+      of the layer / NN function (returning this `Kernel` as the `ker_fun`)
+      are i.i.d. Gaussian with covariance `nngp`, conditioned on fixed inputs
+      to the layer and i.i.d. Gaussian weights and biases of the layer. For
+      example, passing an input through a CNN layer with i.i.d. Gaussian
+      weights and biases produces i.i.d. Gaussian random variables along the
+      channel dimension, while passing an input through a nonlinearity does
+      not.
     is_height_width: a boolean specifying whether the covariance matrices
       `nngp`, `var1`, `var2`, and `ntk` have `height` dimensions preceding
       `width` or the other way around. Is always set to `True` if `nngp` and
       `ntk` are less than 6-dimensional and alternates between consecutive CNN
       layers otherwise to avoid self-cancelling transpositions.
+    marginal: an instance of `Marginalisation` enum or its ID, specifying
+      types of covariances between spatial dimensions tracked in
+      `var1`/`var2`.
+    cross: an instance of `Marginalisation` enum or its ID, specifying types
+      of covariances between spatial dimensions tracked in `nngp`/`ntk`.
   """
 
-  def __new__(cls, var1, nngp, var2, ntk, is_gaussian, is_height_width):
+  @staticmethod
+  def _cov_match_check(first, second):
+    if isinstance(second, Kernel):
+      marginal1 = Marginalisation(first.marginal)
+      marginal2 = Marginalisation(second.marginal)
+      cross1 = Marginalisation(first.cross)
+      cross2 = Marginalisation(second.cross)
+
+      if not (marginal1 == marginal2 and cross1 == cross2):
+        raise ValueError('The types covariances stored do not match. '
+                         'nngp/ntk covariance type stored: {} vs. {} '
+                         'var1/var2 covariance type stored: {} vs {} '.format(
+            marginal1, marginal2, cross1, cross2))
+
+
+  def __new__(cls, var1, nngp, var2, ntk, is_gaussian, is_height_width,
+              marginal, cross):
     """Returns a `Kernel`.
 
     Args:
       var1: variances of the first batch of inputs. A `np.ndarray` with shape
-        `[batch_size_1]`  for fully-connected networks or `[batch_size_1,
-        height, width]` for CNNs.
+        `[batch_size_1]` for fully-connected networks, or matching the one
+        specified by the `marginal` argument for CNNs with `batch_size_1` for
+        data dimension(s).
       nngp: covariance between the first and second input (NNGP). A `np.ndarray`
         of shape `[batch_size_1, batch_size_2]` for fully-connected networks, or
-        `[batch_size_1, batch_size_2, height, height, width, width]` or
-        `[batch_size_1, batch_size_2, height, width]` for CNNs if pooling is
-        used or not respectively.
+        matching the one specifed by the `cross` argument for CNNs with
+        `[batch_size_1, batch_size_2]` for data dimensions.
       var2: optional variances of the second batch of inputs. A `np.ndarray`
-        with shape `[batch_size_2]` for fully-connected networks or
-        `[batch_size_2, height, width]` for CNNs.
+        with shape `[batch_size_2]` for fully-connected networks or matching
+        the one  specified by the `marginal` argument for CNNs with
+        `batch_size_2` for data dimension(s).
       ntk: the neural tangent kernel (NTK). `np.ndarray` of same shape as
         `nngp`.
       is_gaussian: a boolean, specifying whether the output features or channels
@@ -80,37 +149,59 @@ class Kernel(
         `width` or the other way around. Is always set to `True` if `nngp` and
         `ntk` are less than 6-dimensional and alternates between consecutive CNN
         layers otherwise to avoid self-cancelling transpositions.
+      marginal: an instance of `Marginalisation` enum or its ID, specifying
+        types of covariances between spatial dimensions tracked in
+        `var1`/`var2`.
+      cross: an instance of `Marginalisation` enum or its ID, specifying types
+        of covariances between spatial dimensions tracked in `nngp`/`ntk`.
 
     Returns:
       A `Kernel`.
     """
-    return super(Kernel, cls).__new__(cls, var1, nngp, var2, ntk, is_gaussian,
-                                      is_height_width)
+    def _convert(marg):
+      if marg is None or isinstance(marg, (int, Marginalisation)):
+        return Marginalisation(marg).value
+      else:
+        return marg
+      #TODO(jirihron): parallel + tree_map pass `object` for `marginal`, `cross`
+      # and other arguments which does not go well with Marginalisation(marg)
+
+    return super(Kernel, cls).__new__(
+        cls, var1, nngp, var2, ntk, is_gaussian, is_height_width,
+        _convert(marginal), _convert(cross))
 
   def __add__(self, other):
+    Kernel._cov_match_check(self, other)
     return Kernel(_add(self.var1, other.var1),
                   _add(self.nngp, other.nngp),
                   _add(self.var2, other.var2),
                   _add(self.ntk, other.ntk),
                   _add(self.is_gaussian, other.is_gaussian),
-                  _add(self.is_height_width, other.is_height_width))
+                  _add(self.is_height_width, other.is_height_width),
+                  marginal=self.marginal,
+                  cross=self.cross)
 
   def __truediv__(self, other):
+    Kernel._cov_match_check(self, other)
     return Kernel(_div(self.var1, other),
                   _div(self.nngp, other),
                   _div(self.var2, other),
                   _div(self.ntk, other),
                   self.is_gaussian,
-                  self.is_height_width)
+                  self.is_height_width,
+                  marginal=self.marginal,
+                  cross=self.cross)
 
   def __mul__(self, other):
+    Kernel._cov_match_check(self, other)
     return Kernel(_mul(self.var1, other),
                   _mul(self.nngp, other),
                   _mul(self.var2, other),
                   _mul(self.ntk, other),
                   self.is_gaussian,
-                  self.is_height_width)
-
+                  self.is_height_width,
+                  marginal=self.marginal,
+                  cross=self.cross)
 
 def _add(x, y):
   error = ValueError('x and y must be of the same type, got %s and %s.'

--- a/neural_tangents/utils/monte_carlo.py
+++ b/neural_tangents/utils/monte_carlo.py
@@ -66,7 +66,9 @@ def _get_ker_fun_sample_many(ker_fun_sample_once,
                          var2=None,
                          ntk=0. if compute_ntk else None,
                          is_gaussian=None,
-                         is_height_width=None)
+                         is_height_width=None,
+                         marginal=None,
+                         cross=None)
     for subkey in key:
       ker_sampled += ker_fun_sample_once(x1, x2, subkey)
 


### PR DESCRIPTION
in `var1`/`var2` and  `nngp`/`ntk`. This fixes the bug in average pooling
which requires pixel-pixel covariances to be tracked in `var1`/`var2`
and prepares the ground for incorporation of attention layers.

1) Adding `marginal` and `cross` attributes to `utils.Kernel`,
specifying covariances between which dimensions are to be tracked in
`var1`/`var2` and `nngp`/`ntk` respectively.

2) Methods `_input_to_kernel`, `_transform_kernels_ab_relu`,
`_transform_kernels_erf`, and the layers `Conv`, `Flatten`, `AvgPool`,
and `GlobalAvgPool` are now capable of computing `var1`\`var2`
pixel-pixel covariances.

3) Fixes the bug in `AvgPoll` and `GlobalAvgPool`. Both now correctly
use pixel-pixel covariances in the computation of `ker_fun`.

Tests: all pass modulo the pre-existing issues with `predict_test_tpu`
and one monte_carlo_test which times out

http://sponge/9a2e0d5d-2292-4096-aeab-1e579e2ce348

PiperOrigin-RevId: 270403443