### PR TITLE
fix major typo in colab notebook

### DIFF
--- a/notebooks/neural_tangents_cookbook.ipynb
+++ b/notebooks/neural_tangents_cookbook.ipynb
@@ -591,7 +591,7 @@
         "id": "c3lXqB1t3U9g"
       },
       "source": [
-        "We can use the infinite-width GP defined above to perform exact Bayesian inference using the infinite width network. To do this, we will use the function `neural_tangents.predict.gradient_descent_mse_ensemble` that performs this inference exactly. `predict_fn = nt.predict.gradient_descent_mse_gp(kernel_fn, train_xs, train_ys); mean, cov = predict_fn(x_test=test_xs, get='ntk', compute_cov=True)` computes the mean and covariance of the network evaluated on the test points after training. This `predict_fn` function includes two different modes: in \"NNGP\" mode we compute the Bayesian posterior (which is equivalent to gradient descent with all but the last-layer weights frozen), in \"NTK\" mode we compute the distribution of networks after gradient descent training. "
+        "We can use the infinite-width GP defined above to perform exact Bayesian inference using the infinite width network. To do this, we will use the function `neural_tangents.predict.gradient_descent_mse_ensemble` that performs this inference exactly. `predict_fn = nt.predict.gradient_descent_mse_ensemble(kernel_fn, train_xs, train_ys); mean, cov = predict_fn(x_test=test_xs, get='ntk', compute_cov=True)` computes the mean and covariance of the network evaluated on the test points after training. This `predict_fn` function includes two different modes: in \"NNGP\" mode we compute the Bayesian posterior (which is equivalent to gradient descent with all but the last-layer weights frozen), in \"NTK\" mode we compute the distribution of networks after gradient descent training. "
       ]
     },
     {


### PR DESCRIPTION
the notebook mentions a non-existent attribute: predict_fn = nt.predict.gradient_descent_mse_gp(kernel_fn, train_xs, train_ys)

gradient_descent_mse_gp is used instead of gradient_descent_mse_ensemble