### PR TITLE
Use local device count for pmap in np.batch

### DIFF
--- a/neural_tangents/_src/batching.py
+++ b/neural_tangents/_src/batching.py
@@ -110,7 +110,7 @@ def batch(kernel_fn: _KernelFn,
   input_req = getattr(kernel_fn, 'input_req', {})
   dropout_in_analytic_kernel = input_req.get('use_dropout', False)
   use_multidevice = device_count > 0 or (device_count == -1 and
-                                         jax.device_count() > 1)
+                                         jax.local_device_count() > 1)
   use_serial = bool(batch_size)
   if use_multidevice:
     kernel_fn = _parallel(kernel_fn, use_serial,
@@ -518,7 +518,7 @@ def _parallel(kernel_fn: _KernelFn,
   """
 
   if device_count == -1:
-    device_count = jax.device_count()
+    device_count = jax.local_device_count()
 
   def _check_dropout(n1, n2, kwargs):
     dropout_in_empirical_kernel = getattr(kwargs, 'rng', None) is not None

--- a/neural_tangents/_src/batching.py
+++ b/neural_tangents/_src/batching.py
@@ -696,7 +696,7 @@ def _get_jit_or_pmap_broadcast():
     key = (f, device_count)
 
     if device_count == -1:
-      device_count = jax.device_count()
+      device_count = jax.local_device_count()
 
     # TODO(romann): adapt this when JAX allows `axis_in` for `pmap`.
     def broadcast(arg: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
To work correctly in multi-host contexts, the pmap'ed axis needs to be of the shape of the **local** number of devices, **not** the number of devices across all processes. https://jax.readthedocs.io/en/latest/_autosummary/jax.pmap.html#jax.pmap

This allows `np.batch` to work in a sharded (multi-host) setting, where part of the covariance matrix is distributed on every process.

**Context**

I am working on distributed conjugate gradient support for `nt.predict.gp_inference()`, similar in the spirit to this paper
https://proceedings.neurips.cc/paper/2019/file/01ce84968c6969bdd5d51c5eeaa3946a-Paper.pdf,
and this is the first PR of possibly more to come.

**Additional context**

Here's a code snippet that does a sharded computation on the kernel followed by an all gather. However, it still has `O(N^2)` storage requirement. Could be used for unit testing.
 
```
def eval_distributed(kernel_fn, x1: np.ndarray, x2: np.ndarray, get: str, tile_size: int, **kwargs):
    """Compute the kernel by distributing tiles of size (tile_size, tile_size)
       of the input matrix of shape x1.shape[0] x x2.shape[0]) onto
       different processes, and gathering the result at the end.

       `tile_size` must divide x1.shape[0] and x2.shape[0]

        Args:
            kernel_fn:
              Function that returns a `Kernel` object, with signature `kernel_fn(x1, x2, get, ...)`
            x1:
              First input
            x2:
              Second input
            get:
              string, the mode of the Gaussian process, either "nngp" or "ntk", or a tuple.
              `get=None` is equivalent to `get=("nngp", "ntk")`.
            tile_size:
              The 1d size of (x1, x2) tiles into which the input is decomposed

        Returns:
            A `Kernel` object with `nngp` and/or `ntk` arrays filled, representing
            the combination of sub-kernels evaluated by every process

       """

    nproc = jax.process_count()
    iproc = jax.process_index()

    x1_size = x1.shape[0]
    x2_size = x2.shape[0]
    n_tiles_x1 = x1_size//tile_size
    n_tiles_x2 = x2_size//tile_size

    if x1_size % tile_size:
        raise ValueError("First axis of x1 ({}) does not divide tile_size ({})".format(x1_size, tile_size))
    if x2_size % tile_size:
        raise ValueError("First axis of x2 ({}) does not divide tile_size ({})".format(x2_size, tile_size))

    nngp = None
    ntk = None

    get = (get, ) if not isinstance(get, (tuple,list)) else get

    if any([g not in ('nngp','ntk') for g in get]):
        raise ValueError('Can only evaluate NNGP or NTK kernels in parallel.')

    first_devices = [jax.local_devices(process_index=p)[0] for p in range(nproc)]

    result = []

    offset = iproc
    for g in get:
        ts = []
        while offset < n_tiles_x1*n_tiles_x2:
            i = offset // n_tiles_x2
            j = offset % n_tiles_x2

            x1_tile = x1[i*tile_size:(i+1)*tile_size]
            x2_tile = x2[j*tile_size:(j+1)*tile_size]

            # compute tile
            r = kernel_fn(x1_tile, x2_tile, g, **kwargs)

            # gather results using the first device on every process
            ts += list(pmap(lambda x: jax.lax.all_gather(x, 'i'), axis_name='i', devices=first_devices)(np.expand_dims(r,0))[0])
            offset += nproc

        t = np.block([[ts[i*n_tiles_x2+j] for j in range(n_tiles_x2)] for i in range(n_tiles_x1)])
        result.append(t.reshape((x1_size, x2_size) + r.shape[2:]))

    if len(result) > 1:
        return result
    else:
        return result[0]
```