### PR TITLE
Fix masking with more than one input feature

### DIFF
--- a/neural_tangents/_src/stax/requirements.py
+++ b/neural_tangents/_src/stax/requirements.py
@@ -764,6 +764,11 @@ def _inputs_to_kernel(
     x = _get_masked_array(x, mask_constant)
     x, mask = x.masked_value, x.mask
 
+    # reduce mask
+    if mask_constant and mask.shape[channel_axis] > 1:
+        warnings.warn("Assuming consistent masks (all zero or one) for features of dimension > 1, which is not verified.")
+    mask = np.any(mask, axis=channel_axis, keepdims=True)
+
     # TODO(schsam): Think more about dtype automatic vs manual dtype promotion.
     x = x.astype(jax.dtypes.canonicalize_dtype(np.float64))
 


### PR DESCRIPTION
This PR fixes an issue where passing inputs `x1` and `x2` of dimension `(..., n_feat)` with `n_feat > 1` to a `kernel_fn` generates masks in the Kernel which still carry the original feature dimension.

This creates a problem for layers such as `GlobalAvgPool`, since for kernels that represent infinitely wide layers it is generally assumed that the channel dimension is one.

I implemented a reduction over the mask's last dimension using `np.any(.., keepdims=True)`, which assumes that it doesn't matter if any or all of the features are masked. A user warning spells this out.

I can create an issue with a reproducer shortly, if more detail is needed.