### PR TITLE
Support python 3.12 and misc

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,10 +32,10 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v4.2.1
+    - uses: actions/checkout@v4.2.2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5.2.0
+      uses: actions/setup-python@v5.3.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v4.1.7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5.1.1
+      uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v4.1.7
+    - uses: actions/checkout@v4.2.1
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5.2.0
@@ -54,7 +54,7 @@ jobs:
         JAX_ENABLE_X64=${{ matrix.JAX_ENABLE_X64 }} PYTHONHASHSEED=0 pytest -n auto --cov=neural_tangents --cov-report=xml --cov-report=term
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4.5.0
+      uses: codecov/codecov-action@v4.6.0
       with:
         file: ./coverage.xml
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,10 +32,10 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v4.1.7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5.0.0
+      uses: actions/setup-python@v5.1.1
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -54,7 +54,7 @@ jobs:
         JAX_ENABLE_X64=${{ matrix.JAX_ENABLE_X64 }} PYTHONHASHSEED=0 pytest -n auto --cov=neural_tangents --cov-report=xml --cov-report=term
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4.0.1
+      uses: codecov/codecov-action@v4.5.0
       with:
         file: ./coverage.xml
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, '3.10', 3.11]
+        python-version: [3.9, '3.10', 3.11, 3.12]
         JAX_ENABLE_X64: [0, 1]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, '3.10', 3.11, 3.12]
+        python-version: ['3.10', 3.11, 3.12]
         JAX_ENABLE_X64: [0, 1]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,10 +32,10 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v4.2.1
+    - uses: actions/checkout@v4.2.2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5.2.0
+      uses: actions/setup-python@v5.3.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v4.1.7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5.1.1
+      uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,7 +32,7 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v4.1.7
+    - uses: actions/checkout@v4.2.1
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5.2.0
@@ -54,7 +54,7 @@ jobs:
         JAX_ENABLE_X64=${{ matrix.JAX_ENABLE_X64 }} PYTHONHASHSEED=0 pytest -n auto --cov=neural_tangents --cov-report=xml --cov-report=term
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4.5.0
+      uses: codecov/codecov-action@v4.6.0
       with:
         file: ./coverage.xml
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,10 +32,10 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v4.1.7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5.0.0
+      uses: actions/setup-python@v5.1.1
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -54,7 +54,7 @@ jobs:
         JAX_ENABLE_X64=${{ matrix.JAX_ENABLE_X64 }} PYTHONHASHSEED=0 pytest -n auto --cov=neural_tangents --cov-report=xml --cov-report=term
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4.0.1
+      uses: codecov/codecov-action@v4.5.0
       with:
         file: ./coverage.xml
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: ['3.10', 3.11, 3.12]
         JAX_ENABLE_X64: [0]
 
-    runs-on: macos-14
+    runs-on: macos-latest
 
     steps:
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, '3.10', 3.11]
+        python-version: [3.9, '3.10', 3.11, 3.12]
         JAX_ENABLE_X64: [0]
 
     runs-on: macos-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, '3.10', 3.11, 3.12]
+        python-version: ['3.10', 3.11, 3.12]
         JAX_ENABLE_X64: [0]
 
     runs-on: macos-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: ['3.10', 3.11, 3.12]
         JAX_ENABLE_X64: [0]
 
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
 

--- a/.github/workflows/pytype.yml
+++ b/.github/workflows/pytype.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v4.1.7
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5.1.1
+      uses: actions/setup-python@v5.2.0
       with:
         python-version: '3.10'
 

--- a/.github/workflows/pytype.yml
+++ b/.github/workflows/pytype.yml
@@ -27,7 +27,7 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v4.1.7
+    - uses: actions/checkout@v4.2.1
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v5.2.0

--- a/.github/workflows/pytype.yml
+++ b/.github/workflows/pytype.yml
@@ -27,10 +27,10 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v4.2.1
+    - uses: actions/checkout@v4.2.2
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5.2.0
+      uses: actions/setup-python@v5.3.0
       with:
         python-version: '3.10'
 

--- a/.github/workflows/pytype.yml
+++ b/.github/workflows/pytype.yml
@@ -27,10 +27,10 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v4.1.7
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5.0.0
+      uses: actions/setup-python@v5.1.1
       with:
         python-version: '3.10'
 

--- a/.github/workflows/sketching.yml
+++ b/.github/workflows/sketching.yml
@@ -31,10 +31,10 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v4.1.7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5.0.0
+      uses: actions/setup-python@v5.1.1
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -53,7 +53,7 @@ jobs:
         JAX_ENABLE_X64=${{ matrix.JAX_ENABLE_X64 }} PYTHONHASHSEED=0 pytest experimental/tests/ -n auto --cov=experimental/ --cov-report=xml --cov-report=term
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4.0.1
+      uses: codecov/codecov-action@v4.5.0
       with:
         file: ./coverage.xml
 

--- a/.github/workflows/sketching.yml
+++ b/.github/workflows/sketching.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v4.1.7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5.1.1
+      uses: actions/setup-python@v5.2.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/sketching.yml
+++ b/.github/workflows/sketching.yml
@@ -31,7 +31,7 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v4.1.7
+    - uses: actions/checkout@v4.2.1
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5.2.0
@@ -53,7 +53,7 @@ jobs:
         JAX_ENABLE_X64=${{ matrix.JAX_ENABLE_X64 }} PYTHONHASHSEED=0 pytest experimental/tests/ -n auto --cov=experimental/ --cov-report=xml --cov-report=term
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4.5.0
+      uses: codecov/codecov-action@v4.6.0
       with:
         file: ./coverage.xml
 

--- a/.github/workflows/sketching.yml
+++ b/.github/workflows/sketching.yml
@@ -31,10 +31,10 @@ jobs:
       uses: styfle/cancel-workflow-action@0.12.1
       with:
         access_token: ${{ github.token }}
-    - uses: actions/checkout@v4.2.1
+    - uses: actions/checkout@v4.2.2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5.2.0
+      uses: actions/setup-python@v5.3.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ from jax.example_libraries import stax
 init_fn, apply_fn = stax.serial(
     stax.Dense(512), stax.Relu,
     stax.Dense(512), stax.Relu,
-    stax.Dense(1)
+    stax.Dense(1),
 )
 
 key = random.PRNGKey(1)
@@ -123,7 +123,7 @@ from neural_tangents import stax
 init_fn, apply_fn, kernel_fn = stax.serial(
     stax.Dense(512), stax.Relu(),
     stax.Dense(512), stax.Relu(),
-    stax.Dense(1)
+    stax.Dense(1),
 )
 
 key1, key2 = random.split(random.PRNGKey(1))

--- a/examples/datasets.py
+++ b/examples/datasets.py
@@ -44,7 +44,7 @@ def get_dataset(
     permute_train=False,
     do_flatten_and_normalize=True,
     data_dir=None,
-    input_key='image'
+    input_key='image',
 ):
   """Download, parse and process a dataset to unit scale and one-hot labels."""
   # Need this following http://cl/378185881 to prevent GPU test breakages.
@@ -133,9 +133,10 @@ def embed_glove(xs, glove_path, max_sentence_length=1000, mask_constant=1000.):
   xs = list(map(_decode, xs))
   tokenizer = tf.keras.preprocessing.text.Tokenizer()
   tokenizer.fit_on_texts(np.concatenate(xs))
-  glove_embedding_layer = _get_glove_embedding_layer(tokenizer,
-                                                     glove_path,
-                                                     max_sentence_length)
+  glove_embedding_layer = _get_glove_embedding_layer(
+      tokenizer,
+      glove_path,
+  )
 
   def embed(x):
     # Replace strings with sequences of integer tokens.
@@ -147,7 +148,8 @@ def embed_glove(xs, glove_path, max_sentence_length=1000, mask_constant=1000.):
         x_tok,
         max_sentence_length,
         padding='post',
-        truncating='post')
+        truncating='post',
+    )
 
     # Replace integer tokens with word embeddings.
     x_emb = glove_embedding_layer(x_tok).numpy()
@@ -160,7 +162,7 @@ def embed_glove(xs, glove_path, max_sentence_length=1000, mask_constant=1000.):
   return map(embed, xs)
 
 
-def _get_glove_embedding_layer(tokenizer, glove_path, max_sentence_length):
+def _get_glove_embedding_layer(tokenizer, glove_path):
   """Get a Keras embedding layer for a given GloVe embeddings.
 
   Adapted from https://keras.io/examples/pretrained_word_embeddings/.
@@ -171,9 +173,6 @@ def _get_glove_embedding_layer(tokenizer, glove_path, max_sentence_length):
 
     glove_path:
       path to the GloVe embedding file.
-
-    max_sentence_length:
-      pad/truncate embeddings to this length.
 
   Returns:
     Keras embedding layer for a given GloVe embeddings.
@@ -212,8 +211,8 @@ def _get_glove_embedding_layer(tokenizer, glove_path, max_sentence_length):
     embedding_layer = tf.keras.layers.Embedding(
         num_words, embedding_dim,
         embeddings_initializer=tf.keras.initializers.Constant(emb_mat),
-        input_length=max_sentence_length,
-        trainable=False)
+        trainable=False,
+    )
 
   return embedding_layer
 

--- a/examples/function_space.py
+++ b/examples/function_space.py
@@ -57,7 +57,7 @@ def main(unused_argv):
   opt_init, opt_apply, get_params = optimizers.sgd(_LEARNING_RATE)
   state = opt_init(params)
 
-  # Create an mse loss function and a gradient function.
+  # Create a mse loss function and a gradient function.
   loss = lambda fx, y_hat: 0.5 * jnp.mean((fx - y_hat) ** 2)
   grad_loss = jit(grad(lambda params, x, y: loss(apply_fn(params, x), y)))
 

--- a/examples/imdb.py
+++ b/examples/imdb.py
@@ -99,7 +99,7 @@ def main(*args, use_dummy_data: bool = False, **kwargs) -> None:
 
 
 def _get_dummy_data(
-    mask_constant: float
+    mask_constant: float,
 ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
   """Return dummy data for when downloading embeddings is not feasible."""
   n_train, n_test = 6, 6

--- a/neural_tangents/_src/predict.py
+++ b/neural_tangents/_src/predict.py
@@ -1142,7 +1142,7 @@ def max_learning_rate(
 
   if _is_on_cpu(ntk_train_train):
     max_eva = sp.linalg.eigvalsh(ntk_train_train,
-                                 subset_by_index=(ntk_train_train.shape[0] - 1,))  # pytype: disable=attribute-error  # jax-ndarray
+                                 subset_by_index=(ntk_train_train.shape[0] - 1,) * 2)  # pytype: disable=attribute-error  # jax-ndarray
   else:
     max_eva = jnp.linalg.eigvalsh(ntk_train_train)[-1]
   lr = 2 * (1 + momentum) * factor / (max_eva + eps)

--- a/neural_tangents/_src/predict.py
+++ b/neural_tangents/_src/predict.py
@@ -1142,7 +1142,7 @@ def max_learning_rate(
 
   if _is_on_cpu(ntk_train_train):
     max_eva = sp.linalg.eigvalsh(ntk_train_train,
-                                 subset_by_index=(ntk_train_train.shape[0] - 1,) * 2)  # pytype: disable=attribute-error  # jax-ndarray
+                                 subset_by_index=(ntk_train_train.shape[0] - 1,) * 2)[0]  # pytype: disable=attribute-error  # jax-ndarray
   else:
     max_eva = jnp.linalg.eigvalsh(ntk_train_train)[-1]
   lr = 2 * (1 + momentum) * factor / (max_eva + eps)

--- a/neural_tangents/_src/predict.py
+++ b/neural_tangents/_src/predict.py
@@ -1142,8 +1142,7 @@ def max_learning_rate(
 
   if _is_on_cpu(ntk_train_train):
     max_eva = sp.linalg.eigvalsh(ntk_train_train,
-                                 eigvals=(ntk_train_train.shape[0] - 1,  # pytype: disable=attribute-error  # jax-ndarray
-                                          ntk_train_train.shape[0] - 1))[-1]  # pytype: disable=attribute-error  # jax-ndarray
+                                 subset_by_index=(ntk_train_train.shape[0] - 1,))  # pytype: disable=attribute-error  # jax-ndarray
   else:
     max_eva = jnp.linalg.eigvalsh(ntk_train_train)[-1]
   lr = 2 * (1 + momentum) * factor / (max_eva + eps)

--- a/neural_tangents/_src/stax/combinators.py
+++ b/neural_tangents/_src/stax/combinators.py
@@ -203,7 +203,7 @@ def parallel(*layers: Layer) -> InternalLayer:
 
 def _get_input_req_attr(
     kernel_fns: list[LayerKernelFn],
-    fold: Callable[[Diagonal, Diagonal], Diagonal]
+    fold: Callable[[Diagonal, Diagonal], Diagonal],
 ) -> dict[str, Any]:
   """Gets requirements of the combined layer based on individual requirements.
 

--- a/neural_tangents/_src/stax/elementwise.py
+++ b/neural_tangents/_src/stax/elementwise.py
@@ -20,7 +20,7 @@ For details, please see "`Fast Neural Kernel Embeddings for General Activations
 
 import functools
 import operator as op
-from typing import Callable, Optional, Sequence
+from typing import Callable, Sequence
 import warnings
 
 import jax
@@ -49,7 +49,7 @@ from .requirements import supports_masking
 def Erf(
     a: float = 1.,
     b: float = 1.,
-    c: float = 0.
+    c: float = 0.,
 ) -> InternalLayer:
   """Affine transform of `Erf` nonlinearity, i.e. `a * Erf(b * x) + c`.
 
@@ -83,8 +83,8 @@ def Erf(
     def nngp_ntk_fn(
         nngp: jnp.ndarray,
         prod: jnp.ndarray,
-        ntk: Optional[jnp.ndarray] = None
-    ) -> tuple[jnp.ndarray, Optional[jnp.ndarray]]:
+        ntk: jnp.ndarray | None = None,
+    ) -> tuple[jnp.ndarray, jnp.ndarray | None]:
       square_root = _sqrt(prod - 4 * nngp**2)
       nngp = factor * jnp.arctan2(2 * nngp, square_root)
 
@@ -153,8 +153,8 @@ def Gabor() -> InternalLayer:
         nngp: jnp.ndarray,
         prod: jnp.ndarray,
         sum_: jnp.ndarray,
-        ntk: Optional[jnp.ndarray] = None
-    ) -> tuple[jnp.ndarray, Optional[jnp.ndarray]]:
+        ntk: jnp.ndarray | None = None,
+    ) -> tuple[jnp.ndarray, jnp.ndarray | None]:
       diff = 4 * (prod - nngp**2)
       denom = 2 * sum_ + diff + 1
       num = sum_ + diff + 2 * nngp
@@ -229,8 +229,8 @@ def Gelu(approximate: bool = False) -> InternalLayer:
         nngp: jnp.ndarray,
         prod: jnp.ndarray,
         prod_plus_1: jnp.ndarray,
-        ntk: Optional[jnp.ndarray] = None
-    ) -> tuple[jnp.ndarray, Optional[jnp.ndarray]]:
+        ntk: jnp.ndarray | None = None,
+    ) -> tuple[jnp.ndarray, jnp.ndarray | None]:
       delta_squared = prod_plus_1 - nngp**2
       delta = _sqrt(delta_squared)
       angles = jnp.arctan2(nngp, delta)
@@ -277,7 +277,7 @@ def Gelu(approximate: bool = False) -> InternalLayer:
 def Sin(
     a: float = 1.,
     b: float = 1.,
-    c: float = 0.
+    c: float = 0.,
 ) -> InternalLayer:
   """Affine transform of `Sin` nonlinearity, i.e. `a sin(b*x + c)`.
 
@@ -331,7 +331,7 @@ def Sin(
 def Cos(
     a: float = 1.,
     b: float = 1.,
-    c: float = 0.
+    c: float = 0.,
 ) -> InternalLayer:
   """Affine transform of `Cos` nonlinearity, i.e. `a cos(b*x + c)`.
 
@@ -405,7 +405,7 @@ def Rbf(gamma: float = 1.0) -> InternalLayer:
 def ABRelu(
     a: float,
     b: float,
-    do_stabilize: bool = False
+    do_stabilize: bool = False,
 ) -> InternalLayer:
   """ABReLU nonlinearity, i.e. `a * min(x, 0) + b * max(x, 0)`.
 
@@ -618,8 +618,8 @@ def Gaussian(a: float = 1, b: float = -1) -> InternalLayer:
     def nngp_ntk_fn(
         nngp: jnp.ndarray,
         prod: jnp.ndarray,
-        ntk: Optional[jnp.ndarray] = None
-    ) -> tuple[jnp.ndarray, Optional[jnp.ndarray]]:
+        ntk: jnp.ndarray | None = None,
+    ) -> tuple[jnp.ndarray, jnp.ndarray | None]:
       det = _sqrt((prod - factor * nngp**2))
 
       if ntk is not None:
@@ -652,7 +652,7 @@ def Gaussian(a: float = 1, b: float = -1) -> InternalLayer:
 def ExpNormalized(
     gamma: float = 1,
     shift: float = -1,
-    do_clip: bool = False
+    do_clip: bool = False,
 ) -> InternalLayer:
   """Simulates the "Gaussian normalized kernel".
 
@@ -779,8 +779,8 @@ def Monomial(degree: int) -> InternalLayer:
     def nngp_ntk_fn(
         nngp: jnp.ndarray,
         prod: jnp.ndarray,
-        ntk: Optional[jnp.ndarray] = None
-    ) -> tuple[jnp.ndarray, Optional[jnp.ndarray]]:
+        ntk: jnp.ndarray | None = None,
+    ) -> tuple[jnp.ndarray, jnp.ndarray | None]:
 
       def nngp_fn(nngp: jnp.ndarray, degree: int) -> jnp.ndarray:
         if degree == -1:
@@ -885,8 +885,8 @@ def RectifiedMonomial(degree: int) -> InternalLayer:
     def nngp_ntk_fn(
         nngp: jnp.ndarray,
         prod: jnp.ndarray,
-        ntk: Optional[jnp.ndarray] = None
-    ) -> tuple[jnp.ndarray, Optional[jnp.ndarray]]:
+        ntk: jnp.ndarray | None = None,
+    ) -> tuple[jnp.ndarray, jnp.ndarray | None]:
 
       sqrt_prod = _sqrt(prod)
       coeff = sqrt_prod**degree / (2 * jnp.pi)
@@ -944,7 +944,7 @@ def Polynomial(coef: Sequence[float]) -> InternalLayer:
   def kernel_fn(k: Kernel) -> Kernel:
     cov1, nngp, cov2, ntk = k.cov1, k.nngp, k.cov2, k.ntk
 
-    def r(n: Optional[jnp.ndarray], l: int) -> Optional[jnp.ndarray]:
+    def r(n: jnp.ndarray, l: int) -> jnp.ndarray | None:
       if n is None:
         return None
 
@@ -979,8 +979,8 @@ def Polynomial(coef: Sequence[float]) -> InternalLayer:
         nngp: jnp.ndarray,
         prod: jnp.ndarray,
         r_prods: Sequence[jnp.ndarray],
-        ntk: Optional[jnp.ndarray] = None
-    ) -> tuple[jnp.ndarray, Optional[jnp.ndarray]]:
+        ntk: jnp.ndarray | None = None,
+    ) -> tuple[jnp.ndarray, jnp.ndarray | None]:
       ratio = nngp / _sqrt(prod)
 
       if ntk is not None:
@@ -995,8 +995,10 @@ def Polynomial(coef: Sequence[float]) -> InternalLayer:
 
       return nngp, ntk
 
-    def nngp_fn_diag(nngp: jnp.ndarray,
-                     r_prods: Sequence[jnp.ndarray]) -> jnp.ndarray:
+    def nngp_fn_diag(
+        nngp: jnp.ndarray,
+        r_prods: Sequence[jnp.ndarray],
+    ) -> jnp.ndarray:
       out = jnp.zeros_like(nngp)
       for l in range(degree):
         out += r_prods[l]
@@ -1022,9 +1024,9 @@ def Polynomial(coef: Sequence[float]) -> InternalLayer:
 @layer
 @supports_masking(remask_kernel=True)
 def Elementwise(
-    fn: Optional[Callable[[float], float]] = None,
-    nngp_fn: Optional[Callable[[float, float, float], float]] = None,
-    d_nngp_fn: Optional[Callable[[float, float, float], float]] = None
+    fn: Callable[[float], float] | None = None,
+    nngp_fn: Callable[[float, float, float], float] | None = None,
+    d_nngp_fn: Callable[[float, float, float], float] | None = None,
 ) -> InternalLayer:
   """Elementwise application of `fn` using provided `nngp_fn`.
 
@@ -1036,8 +1038,8 @@ def Elementwise(
   numerical integration or `nt.monte_carlo.monte_carlo_kernel_fn` to use Monte
   Carlo sampling.
 
-  If your function is implemented separately (e.g. `nt.stax.Relu` etc) it's best
-  to use the custom implementation, since it uses symbolically simplified
+  If your function is implemented separately (e.g. `nt.stax.Relu` etc.) it's
+  best to use the custom implementation, since it uses symbolically simplified
   expressions that are more precise and numerically stable.
 
   For details, please see "`Fast Neural Kernel Embeddings for General
@@ -1134,7 +1136,7 @@ def Elementwise(
 def ElementwiseNumerical(
     fn: Callable[[float], float],
     deg: int,
-    df: Optional[Callable[[float], float]] = None
+    df: Callable[[float], float] | None = None,
 ) -> InternalLayer:
   """Activation function using numerical integration.
 
@@ -1206,7 +1208,7 @@ def ElementwiseNumerical(
       q11, q22 = jnp.expand_dims(q11, xy_axes), jnp.expand_dims(q22, xy_axes)
 
       def integrate(f):
-        fvals = f(_sqrt(2 * q11) * x) * f(  # pytype: disable=wrong-arg-types  # jnp-type
+        fvals = f(_sqrt(2 * q11) * x) * f(
             nngp / _sqrt(q11 / 2, 1e-30) * x + _sqrt(
                 2*(q22 - nngp**2/q11)) * y)
         return jnp.tensordot(grid, fvals, (xy_axes, xy_axes)) / jnp.pi
@@ -1248,9 +1250,9 @@ def ElementwiseNumerical(
 
 
 def _elementwise(
-    fn: Optional[Callable[[float], float]],
+    fn: Callable[[float], float] | None,
     name: str,
-    kernel_fn: Optional[LayerKernelFn],
+    kernel_fn: LayerKernelFn | None,
 ) -> InternalLayer:
   init_fn = lambda rng, input_shape: (input_shape, ())
 
@@ -1291,7 +1293,7 @@ def _sqrt_jvp(tol, primals, tangents):
 
 
 @functools.partial(custom_jvp, nondiff_argnums=(2,))
-def _arctan2(x, y, fill_zero: Optional[float] = None):
+def _arctan2(x, y, fill_zero: float | None = None):
   if fill_zero is not None:
     return jnp.where(jnp.bitwise_and(x == 0., y == 0.),
                      fill_zero,
@@ -1314,9 +1316,9 @@ def _vmap_2d(
     fn: Callable[[float, float, float], float],
     cov12: jnp.ndarray,
     var1: jnp.ndarray,
-    var2: Optional[jnp.ndarray],
+    var2: jnp.ndarray | None,
     diagonal_batch: bool,
-    diagonal_spatial: bool
+    diagonal_spatial: bool,
 ) -> jnp.ndarray:
   """Effectively a "2D vmap" of `fn(cov12, var1, var2)`.
 

--- a/neural_tangents/experimental/empirical_tf/empirical.py
+++ b/neural_tangents/experimental/empirical_tf/empirical.py
@@ -22,7 +22,7 @@ The kernel function follows the API of :obj:`neural_tangents.empirical_ntk_fn`.
 Please read the respective docstring for more details.
 
 .. warning::
-  This module currently appears to have long compile times (but OK runtime),
+  This module currently appears to have long compilation times (but OK runtime),
   is prone to triggering XLA errors, and does not distinguish between trainable
   and non-trainable parameters of the model.
 
@@ -50,7 +50,7 @@ Example:
   >>> f.build((None, *x_train.shape[1:]))
   >>> _, params = nt.experimental.get_apply_fn_and_params(f)
   >>> #
-  >>> # Default setting: reducing over logits (default `trace_axes=(-1,)`;
+  >>> # Default setting: reducing over logits (default `trace_axes=(-1,)`);
   >>> # pass `vmap_axes=0` because the network is iid along the batch axis, no
   >>> # BatchNorm.
   >>> kernel_fn = nt.experimental.empirical_ntk_fn_tf(f, vmap_axes=0)
@@ -91,7 +91,7 @@ Example:
   >>> ntk_train_train_diag = ntk_fn(x_train, None, params)
 """
 
-from typing import Callable, Optional, Union
+from typing import Callable
 import warnings
 
 from jax.experimental import jax2tf
@@ -110,14 +110,14 @@ import tf2jax
 
 
 def empirical_ntk_fn_tf(
-    f: Union[tf.Module, tf.types.experimental.PolymorphicFunction, keras.Model],
+    f: tf.Module | tf.types.experimental.PolymorphicFunction | keras.Model,
     trace_axes: Axes = (-1,),
     diagonal_axes: Axes = (),
     vmap_axes: VMapAxes = None,
-    implementation: Union[NtkImplementation, int] = DEFAULT_NTK_IMPLEMENTATION,
+    implementation: NtkImplementation | int = DEFAULT_NTK_IMPLEMENTATION,
     _j_rules: bool = _DEFAULT_NTK_J_RULES,
     _s_rules: bool = _DEFAULT_NTK_S_RULES,
-    _fwd: Optional[bool] = _DEFAULT_NTK_FWD,
+    _fwd: bool | None = _DEFAULT_NTK_FWD,
 ) -> Callable[..., PyTree]:
   r"""Returns a function to draw a single sample the NTK of a given network `f`.
 
@@ -134,9 +134,9 @@ def empirical_ntk_fn_tf(
     compile times (but OK runtime), is prone to triggering XLA errors, and does
     not distinguish between trainable and non-trainable parameters of the model.
 
-  TODO(romann): support division between trainable and non-trainable variables.
+  TODO: support division between trainable and non-trainable variables.
 
-  TODO(romann): investigate slow compile times.
+  TODO: investigate slow compile times.
 
   Args:
     f:
@@ -265,7 +265,7 @@ def empirical_ntk_fn_tf(
   return ntk_fn
 
 
-def get_apply_fn_and_params(f: Union[tf.Module, keras.Model]):
+def get_apply_fn_and_params(f: tf.Module | keras.Model):
   """Converts a :class:`tf.Module` into a forward-pass `apply_fn` and `params`.
 
   Use this function to extract `params` to pass to the Tensorflow empirical NTK

--- a/neural_tangents/predict.py
+++ b/neural_tangents/predict.py
@@ -23,5 +23,5 @@ from ._src.predict import (
     max_learning_rate,
 
     ODEState,
-    Gaussian
+    Gaussian,
 )

--- a/neural_tangents/stax.py
+++ b/neural_tangents/stax.py
@@ -77,7 +77,7 @@ Example:
 from ._src.stax.combinators import (
     parallel,
     serial,
-    repeat
+    repeat,
 )
 
 
@@ -131,7 +131,7 @@ from ._src.stax.linear import (
 
 # Helper object for the `Index` layer.
 from ._src.stax.linear import (
-    Slice
+    Slice,
 )
 
 

--- a/notebooks/empirical_ntk_resnet.ipynb
+++ b/notebooks/empirical_ntk_resnet.ipynb
@@ -85,7 +85,7 @@
    "outputs": [],
    "source": [
     "from functools import partial\n",
-    "from typing import Any, Callable, Sequence, Optional\n",
+    "from typing import Any, Callable, Sequence\n",
     "from flax import linen as nn\n",
     "from jax import jit\n",
     "from jax import numpy as jnp\n",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 
 INSTALL_REQUIRES = [
-    'jax>=0.4.32',
+    'jax>=0.4.31',
     'frozendict>=2.4.4',
     'tensorflow>=2.16.2',
     'keras>=3.5.0',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ INSTALL_REQUIRES = [
     'jax>=0.4.25',
     'frozendict>=2.4.0',
     'tensorflow>=2.16.1',
-    'keras>=3.0.5',
+    'keras>=3.1.1',
     'tf2jax @ git+https://github.com/google-deepmind/tf2jax',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 INSTALL_REQUIRES = [
     'jax>=0.4.34',
     'frozendict>=2.4.6',
-    'tensorflow>=2.17.1',
+    'tensorflow>=2.16.1',
     'keras>=3.6.0',
     'tf2jax>=0.3.6',
 ]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ INSTALL_REQUIRES = [
     'frozendict>=2.4.4',
     'tensorflow>=2.17',
     'keras>=3.5.0',
-    'tf2jax @ git+https://github.com/google-deepmind/tf2jax',
+    'tf2jax>=0.3.6',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 INSTALL_REQUIRES = [
     'jax>=0.4.34',
     'frozendict>=2.4.6',
-    'tensorflow>=2.16.1',
+    'tensorflow>=2.16.2',
     'keras>=3.6.0',
     'tf2jax>=0.3.6',
 ]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 INSTALL_REQUIRES = [
     'jax>=0.4.31',
     'frozendict>=2.4.4',
-    'tensorflow>=2.17',
+    'tensorflow>=2.16.2',
     'keras>=3.5.0',
     'tf2jax>=0.3.6',
 ]

--- a/setup.py
+++ b/setup.py
@@ -26,18 +26,18 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 
 INSTALL_REQUIRES = [
-    'jax>=0.4.30',
+    'jax>=0.4.32',
     'frozendict>=2.4.4',
     'tensorflow>=2.17',
-    'keras>=3.4.1',
+    'keras>=3.5.0',
     'tf2jax @ git+https://github.com/google-deepmind/tf2jax',
 ]
 
 
 TESTS_REQUIRES = [
-    'more-itertools',
+    'more-itertools>=10.4.0',
     'tensorflow-datasets>=4.9.6',
-    'flax>=0.8.5',
+    'flax>=0.9.0',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -117,9 +117,8 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     description='Fast and Easy Infinite Neural Networks in Python',
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     classifiers=[
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 INSTALL_REQUIRES = [
     'jax>=0.4.34',
-    'frozendict>=2.4.5',
+    'frozendict>=2.4.6',
     'tensorflow>=2.16.2',
     'keras>=3.6.0',
     'tf2jax>=0.3.6',
@@ -37,7 +37,7 @@ INSTALL_REQUIRES = [
 TESTS_REQUIRES = [
     'more-itertools>=10.5.0',
     'tensorflow-datasets>=4.9.6',
-    'flax>=0.9.0',
+    'flax>=0.10.0',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 
 INSTALL_REQUIRES = [
-    'jax>=0.4.32',
+    'jax>=0.4.31',
     'frozendict>=2.4.4',
     'tensorflow>=2.17',
     'keras>=3.5.0',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ INSTALL_REQUIRES = [
     'jax>=0.4.25',
     'frozendict>=2.4.0',
     'tensorflow>=2.16.1',
-    'keras>=3.1.0',
+    'keras>=3.0.5',
     'tf2jax @ git+https://github.com/google-deepmind/tf2jax',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ INSTALL_REQUIRES = [
     'jax>=0.4.25',
     'frozendict>=2.4.0',
     'tensorflow>=2.16.1',
-    'tf2jax>=0.3.5',
+    'tf2jax @ git+https://github.com/google-deepmind/tf2jax',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 INSTALL_REQUIRES = [
     'jax>=0.4.34',
     'frozendict>=2.4.6',
-    'tensorflow>=2.16.2',
+    'tensorflow>=2.18.0',
     'keras>=3.6.0',
     'tf2jax>=0.3.6',
 ]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 INSTALL_REQUIRES = [
     'jax>=0.4.34',
     'frozendict>=2.4.5',
-    'tensorflow>=2.17',
+    'tensorflow>=2.16.2',
     'keras>=3.6.0',
     'tf2jax>=0.3.6',
 ]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 INSTALL_REQUIRES = [
     'jax>=0.4.34',
     'frozendict>=2.4.6',
-    'tensorflow>=2.16.2',
+    'tensorflow>=2.17.1',
     'keras>=3.6.0',
     'tf2jax>=0.3.6',
 ]

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: MacOS',
         'Operating System :: POSIX :: Linux',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ INSTALL_REQUIRES = [
 
 TESTS_REQUIRES = [
     'more-itertools',
-    'tensorflow-datasets',
+    'tensorflow-datasets @ git+https://github.com/tensorflow/datasets',
     'flax>=0.8.2',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 INSTALL_REQUIRES = [
     'jax>=0.4.16',
     'frozendict>=2.3.8',
-    'tensorflow>=2.15.0',
+    'tensorflow>=2.16.1',
     'tf2jax>=0.3.5',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 
 INSTALL_REQUIRES = [
-    'jax>=0.4.16',
-    'frozendict>=2.3.8',
+    'jax>=0.4.26',
+    'frozendict>=2.4.0',
     'tensorflow>=2.16.1',
     'tf2jax>=0.3.5',
 ]
@@ -36,7 +36,7 @@ INSTALL_REQUIRES = [
 TESTS_REQUIRES = [
     'more-itertools',
     'tensorflow-datasets',
-    'flax>=0.7.2',
+    'flax>=0.8.2',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ INSTALL_REQUIRES = [
     'jax>=0.4.25',
     'frozendict>=2.4.0',
     'tensorflow>=2.16.1',
+    'keras>=3.1.0',
     'tf2jax @ git+https://github.com/google-deepmind/tf2jax',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 
 INSTALL_REQUIRES = [
-    'jax>=0.4.31',
+    'jax>=0.4.32',
     'frozendict>=2.4.4',
     'tensorflow>=2.17',
     'keras>=3.5.0',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 INSTALL_REQUIRES = [
     'jax>=0.4.16',
     'frozendict>=2.3.8',
-    'tensorflow>=2.16.1',
+    'tensorflow>=2.15.0',
     'tf2jax>=0.3.5',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -26,18 +26,18 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 
 INSTALL_REQUIRES = [
-    'jax>=0.4.25',
-    'frozendict>=2.4.0',
-    'tensorflow>=2.16.1',
-    'keras>=3.1.1',
+    'jax>=0.4.30',
+    'frozendict>=2.4.4',
+    'tensorflow>=2.17',
+    'keras>=3.4.1',
     'tf2jax @ git+https://github.com/google-deepmind/tf2jax',
 ]
 
 
 TESTS_REQUIRES = [
     'more-itertools',
-    'tensorflow-datasets @ git+https://github.com/tensorflow/datasets',
-    'flax>=0.8.2',
+    'tensorflow-datasets>=4.9.6',
+    'flax>=0.8.5',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,16 +26,16 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 
 INSTALL_REQUIRES = [
-    'jax>=0.4.32',
-    'frozendict>=2.4.4',
-    'tensorflow>=2.16.2',
-    'keras>=3.5.0',
+    'jax>=0.4.34',
+    'frozendict>=2.4.5',
+    'tensorflow>=2.17',
+    'keras>=3.6.0',
     'tf2jax>=0.3.6',
 ]
 
 
 TESTS_REQUIRES = [
-    'more-itertools>=10.4.0',
+    'more-itertools>=10.5.0',
     'tensorflow-datasets>=4.9.6',
     'flax>=0.9.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 
 INSTALL_REQUIRES = [
-    'jax>=0.4.26',
+    'jax>=0.4.25',
     'frozendict>=2.4.0',
     'tensorflow>=2.16.1',
     'tf2jax>=0.3.5',

--- a/tests/experimental/empirical_ntk_tf_test.py
+++ b/tests/experimental/empirical_ntk_tf_test.py
@@ -15,6 +15,7 @@
 """Tests for `examples/experimental/empirical_ntk_tf.py`."""
 
 from absl.testing import absltest
+import jax
 
 from examples.experimental import empirical_ntk_tf
 
@@ -22,7 +23,8 @@ from examples.experimental import empirical_ntk_tf
 class EmpiricalNtkTfTest(absltest.TestCase):
 
   def test_empirical_ntk_tf_test(self):
-    empirical_ntk_tf.main(None)
+    with jax.rank_promotion('warn'):
+      empirical_ntk_tf.main(None)
 
 
 if __name__ == '__main__':

--- a/tests/experimental/empirical_ntk_tf_test.py
+++ b/tests/experimental/empirical_ntk_tf_test.py
@@ -23,7 +23,7 @@ from examples.experimental import empirical_ntk_tf
 class EmpiricalNtkTfTest(absltest.TestCase):
 
   def test_empirical_ntk_tf_test(self):
-    with jax.rank_promotion('warn'):
+    with jax.numpy_rank_promotion('warn'):
       empirical_ntk_tf.main(None)
 
 

--- a/tests/experimental/empirical_tf_test.py
+++ b/tests/experimental/empirical_tf_test.py
@@ -25,9 +25,6 @@ import numpy as np
 import tensorflow as tf
 
 
-jax.config.update("jax_numpy_rank_promotion", "warn")
-
-
 tf.random.set_seed(1)
 
 
@@ -288,10 +285,11 @@ class EmpiricalTfTest(parameterized.TestCase):
       diagonal_axes,
       vmap_axes,
   ):
-    f = f(classes=1, input_shape=input_shape, weights=None)
-    f.build((None, *input_shape))
-    f_jax, params = experimental.get_apply_fn_and_params(f)
-    self._compare_ntks(f, f_jax, params, trace_axes, diagonal_axes, vmap_axes)
+    with jax.numpy_rank_promotion("warn"):
+      f = f(classes=1, input_shape=input_shape, weights=None)
+      f.build((None, *input_shape))
+      f_jax, params = experimental.get_apply_fn_and_params(f)
+      self._compare_ntks(f, f_jax, params, trace_axes, diagonal_axes, vmap_axes)
 
   @parameterized.product(
       input_shape=[
@@ -316,15 +314,16 @@ class EmpiricalTfTest(parameterized.TestCase):
       diagonal_axes,
       vmap_axes,
   ):
-    f = keras.Sequential()
-    f.add(keras.layers.Conv2D(4, (3, 3), activation='relu'))
-    f.add(keras.layers.Conv2D(2, (2, 2), activation='relu'))
-    f.add(keras.layers.Flatten())
-    f.add(keras.layers.Dense(2))
-
-    f.build((None, *input_shape))
-    f_jax, params = experimental.get_apply_fn_and_params(f)
-    self._compare_ntks(f, f_jax, params, trace_axes, diagonal_axes, vmap_axes)
+    with jax.numpy_rank_promotion("warn"):
+      f = keras.Sequential()
+      f.add(keras.layers.Conv2D(4, (3, 3), activation='relu'))
+      f.add(keras.layers.Conv2D(2, (2, 2), activation='relu'))
+      f.add(keras.layers.Flatten())
+      f.add(keras.layers.Dense(2))
+  
+      f.build((None, *input_shape))
+      f_jax, params = experimental.get_apply_fn_and_params(f)
+      self._compare_ntks(f, f_jax, params, trace_axes, diagonal_axes, vmap_axes)
 
   @parameterized.product(
       f_f_jax=[

--- a/tests/experimental/empirical_tf_test.py
+++ b/tests/experimental/empirical_tf_test.py
@@ -14,6 +14,7 @@
 
 """Tests for `experimental/empirical_tf/empirical.py`."""
 
+import platform
 from absl.testing import absltest
 from absl.testing import parameterized
 import jax
@@ -285,6 +286,8 @@ class EmpiricalTfTest(parameterized.TestCase):
       diagonal_axes,
       vmap_axes,
   ):
+    if platform.system() == 'Darwin':
+      self.skipTest('TF <-> JAX fails on MacOS.')
     with jax.numpy_rank_promotion("warn"):
       f = f(classes=1, input_shape=input_shape, weights=None)
       f.build((None, *input_shape))
@@ -314,6 +317,8 @@ class EmpiricalTfTest(parameterized.TestCase):
       diagonal_axes,
       vmap_axes,
   ):
+    if platform.system() == 'Darwin':
+      self.skipTest('TF <-> JAX fails on MacOS.')
     with jax.numpy_rank_promotion("warn"):
       f = keras.Sequential()
       f.add(keras.layers.Conv2D(4, (3, 3), activation='relu'))
@@ -355,6 +360,8 @@ class EmpiricalTfTest(parameterized.TestCase):
       diagonal_axes,
       vmap_axes,
   ):
+    if platform.system() == 'Darwin':
+      self.skipTest('TF <-> JAX fails on MacOS.')
     f, f_jax = f_f_jax
     f = tf.function(f, input_signature=_input_signature)
     params = tf.random.normal(params_shape, seed=4)
@@ -379,6 +386,8 @@ class EmpiricalTfTest(parameterized.TestCase):
       diagonal_axes,
       vmap_axes,
   ):
+    if platform.system() == 'Darwin':
+      self.skipTest('TF <-> JAX fails on MacOS.')
     f = _MLP(input_size=5, sizes=[4, 6, 3], name='MLP')
     f_jax, params = experimental.get_apply_fn_and_params(f)
     self._compare_ntks(f, f_jax, params, trace_axes, diagonal_axes, vmap_axes)

--- a/tests/experimental/empirical_tf_test.py
+++ b/tests/experimental/empirical_tf_test.py
@@ -229,7 +229,7 @@ class EmpiricalTfTest(parameterized.TestCase):
 
     x1_jax = jnp.array(x1)
     x2_jax = jnp.array(x2)
-    params_jax = jax.tree_map(jnp.array, params)
+    params_jax = jax.tree.map(jnp.array, params)
 
     jax_ntks = [ntk_fn_i(x1_jax, x2_jax, params_jax)
                 for ntk_fn_i in jax_ntk_fns]
@@ -241,7 +241,7 @@ class EmpiricalTfTest(parameterized.TestCase):
       atol = 0.
       rtol = 5e-3
       atol_jax = 0.4
-      rtol_jax = 0.15  # TODO(romann): revisit poor TPU agreement.
+      rtol_jax = 0.15  # TODO: revisit poor TPU agreement.
     else:
       atol = 1e-5
       rtol = 1e-4
@@ -259,7 +259,7 @@ class EmpiricalTfTest(parameterized.TestCase):
   @parameterized.product(
       f=[
           _MiniResNet,
-          # # TODO(romann): MobileNet works, but takes too long to compile.
+          # # TODO: MobileNet works, but takes too long to compile.
           # keras.applications.MobileNet,
       ],
       input_shape=[

--- a/tests/experimental/empirical_tf_test.py
+++ b/tests/experimental/empirical_tf_test.py
@@ -25,6 +25,9 @@ import numpy as np
 import tensorflow as tf
 
 
+jax.config.update("jax_numpy_rank_promotion", "warn")
+
+
 tf.random.set_seed(1)
 
 

--- a/tests/predict_test.py
+++ b/tests/predict_test.py
@@ -50,7 +50,7 @@ if not config.read('jax_enable_x64'):
 FLAT = 'FLAT'
 POOLING = 'POOLING'
 
-# TODO(schsam): Add a pooling test when multiple inputs are supported in
+# TODO: Add a pooling test when multiple inputs are supported in
 # Conv + Pooling.
 TRAIN_SIZES = [4, 8]
 TEST_SIZES = [6, 2]
@@ -114,12 +114,12 @@ class PredictTest(test_utils.NeuralTangentsTestCase):
 
     if momentum is not None:
       # Test state-based prediction
-      state_0 = predict.ODEState(fx_train_0, fx_test_0)  # pytype:disable=wrong-arg-count
+      state_0 = predict.ODEState(fx_train_0, fx_test_0)  # pytype: disable=wrong-arg-count
       state_t0 = predictor(0.0, state_0, None, g_td)
       self.assertAllClose(state_0.fx_train, state_t0.fx_train)
       self.assertAllClose(state_0.fx_test, state_t0.fx_test)
 
-      state_train_only_0 = predict.ODEState(fx_train_0)  # pytype:disable=wrong-arg-count
+      state_train_only_0 = predict.ODEState(fx_train_0)  # pytype: disable=wrong-arg-count
       state_train_only_t0 = predictor(0.0, state_0, None, g_td)
       self.assertAllClose(state_train_only_0.fx_train,
                           state_train_only_t0.fx_train)
@@ -153,7 +153,7 @@ class PredictTest(test_utils.NeuralTangentsTestCase):
     self.assertAllClose(fx_test_concat, fx_test_single)
 
     if momentum is not None:
-      state_0 = predict.ODEState(fx_train_0, fx_test_0)  # pytype:disable=wrong-arg-count
+      state_0 = predict.ODEState(fx_train_0, fx_test_0)  # pytype: disable=wrong-arg-count
       t_1 = (0, 0, 2)
       state_1 = predictor(ts[t_1], state_0, None, g_td)
       self.assertAllClose(fx_train_single[t_1], state_1.fx_train)
@@ -263,8 +263,7 @@ class PredictTest(test_utils.NeuralTangentsTestCase):
 
   @classmethod
   def _cov_empirical(cls, x):
-    return jnp.einsum('itjk,itlk->tjl', x, x, optimize=True) / (x.shape[0] *  # pytype: disable=wrong-arg-types  # jnp-type
-                                                                x.shape[-1])
+    return jnp.einsum('itjk,itlk->tjl', x, x) / (x.shape[0] * x.shape[-1])
 
   @test_utils.product(
       train_size=TRAIN_SIZES[:1],
@@ -301,7 +300,7 @@ class PredictTest(test_utils.NeuralTangentsTestCase):
     self.assertGreater(jnp.min(jnp.linalg.eigh(cov_train_inf)[0]), -1e-8)
 
     _kernel_fn = nt.empirical_kernel_fn(f)
-    # TODO(romann): figure out the slow compile on Ubuntu 22.04 CPU Python 3.9
+    # TODO: figure out the slow compile on Ubuntu 22.04 CPU Python 3.9
     kernel_fn = lambda x1, x2, params: _kernel_fn(x1, x2, 'ntk', params)
 
     def predict_empirical(key):
@@ -676,9 +675,11 @@ class PredictTest(test_utils.NeuralTangentsTestCase):
 
         mean_emp = jnp.mean(ensemble_fx, axis=0, keepdims=True)
         mean_subtracted = ensemble_fx - mean_emp
-        cov_emp = jnp.einsum(  # pytype: disable=wrong-arg-types  # jnp-type
-            'ijk,ilk->jl', mean_subtracted, mean_subtracted, optimize=True) / (
-                mean_subtracted.shape[0] * mean_subtracted.shape[-1])
+        cov_emp = jnp.einsum(
+            'ijk,ilk->jl',
+            mean_subtracted,
+            mean_subtracted,
+        ) / (mean_subtracted.shape[0] * mean_subtracted.shape[-1])
 
         ntk = predict_fn_mse_ens(training_steps, x, 'ntk', compute_cov=True)
         self.assertAllClose(ravel_pytree(mean_emp)[0],
@@ -856,7 +857,7 @@ class PredictTest(test_utils.NeuralTangentsTestCase):
 
                 def is_on_cpu(x):
                   return jax.tree_util.tree_all(
-                      jax.tree_map(
+                      jax.tree.map(
                           lambda x: 'cpu'
                           in str(x.addressable_shards[0].device).lower(),
                           x,
@@ -922,7 +923,7 @@ class PredictTest(test_utils.NeuralTangentsTestCase):
               p_train_mse, p_test_mse = predict_fn_mse(
                   ts, fx_train_0, fx_test_0, ntk_test_train)
               self.assertAllClose(y_test_shape, p_test_mse.shape)
-            self.assertAllClose(y_train_shape, p_train_mse.shape)  # pytype: disable=attribute-error  # jax-ndarray
+            self.assertAllClose(y_train_shape, p_train_mse.shape)
 
             p_nngp_mse_ens, p_ntk_mse_ens = predict_fn_mse_ensemble(
                 ts, x, ('nngp', 'ntk'), compute_cov=True)

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -17,7 +17,7 @@
 import itertools
 import logging
 import random
-from typing import Optional, Sequence
+from typing import Sequence
 import warnings
 
 from absl.testing import absltest
@@ -204,11 +204,11 @@ def _get_f_and_eqn(params, primitive, *inputs):
 
   else:
     if primitive is lax.pad_p:
-      # TODO(romann): find a way to call primitive.bind directly.
+      # TODO: find a way to call primitive.bind directly.
       f = lambda *inputs: lax.pad(*inputs, **params)
 
     elif primitive is lax.conv_general_dilated_p:
-      # TODO(romann): find a way to call primitive.bind directly.
+      # TODO: find a way to call primitive.bind directly.
       f = lambda *inputs: lax.conv_general_dilated(*inputs, **params)
 
     else:
@@ -486,7 +486,7 @@ class JacobianRulesTest(test_utils.NeuralTangentsTestCase):
 
   def _test_primitive(
       self,
-      primitive: Optional[Primitive],
+      primitive: Primitive | None,
       shapes,
       dtype,
       params
@@ -573,7 +573,7 @@ class JacobianRulesTest(test_utils.NeuralTangentsTestCase):
       for primitive in _UNARY_PRIMITIVES.keys()
       for params in _UNARY_PRIMITIVES[primitive](shape, dtype)
   )
-  def test_unary(self, primitive: Optional[Primitive], shape, dtype, params):
+  def test_unary(self, primitive: Primitive | None, shape, dtype, params):
     if primitive == lax.device_put_p:
       # Can't instantiate devices at test generation time; using subtests.
       devices = [None] + jax.devices() + jax.local_devices(backend='cpu')
@@ -602,13 +602,13 @@ class JacobianRulesTest(test_utils.NeuralTangentsTestCase):
   )
   def test_binary(
       self,
-      primitive: Optional[Primitive],
+      primitive: Primitive | None,
       shape1,
       shape2,
       dtype,
       params
   ):
-    # TODO(romann): revisit when bugs below are fixed.
+    # TODO: revisit when bugs below are fixed.
     if primitive == lax.conv_general_dilated_p:
       if jax.default_backend() == 'tpu':
         raise absltest.SkipTest('http://b/235167364')
@@ -633,7 +633,7 @@ class JacobianRulesTest(test_utils.NeuralTangentsTestCase):
       for primitive in _N_ARY_PRIMITIVES.keys()
       for params in _N_ARY_PRIMITIVES[primitive](*shapes)
   )
-  def test_n_ary(self, primitive: Optional[Primitive], shapes, dtype, params):
+  def test_n_ary(self, primitive: Primitive | None, shapes, dtype, params):
     self._test_primitive(primitive, shapes, dtype, params)
 
 

--- a/tests/stax/elementwise_test.py
+++ b/tests/stax/elementwise_test.py
@@ -143,7 +143,7 @@ class ActivationTest(test_utils.NeuralTangentsTestCase):
       cov2 = jnp.reshape(cov2, (1, cov2.shape[0]))
       nngp = kernels.nngp
 
-      # TODO(schsam): Update cov1 and cov2 if we want to compose this kernel
+      # TODO: Update cov1 and cov2 if we want to compose this kernel
       # with other kernels.
       return kernels.replace(
           nngp=jnp.exp(-input_dim * gamma * (cov1 + cov2 - 2 * nngp)))
@@ -697,7 +697,7 @@ class AutodiffTest(test_utils.NeuralTangentsTestCase):
 
     def assert_close(x, y, tol=3e-5):
       if default_backend() == 'tpu':
-        # TODO(romann): understand why TPUs have high errors.
+        # TODO: understand why TPUs have high errors.
         tol = 0.21
       self.assertLess(
           jnp.max(jnp.abs(x - y)) / (jnp.mean(jnp.abs(x)) + jnp.mean(jnp.abs(y))),

--- a/tests/stax/linear_test.py
+++ b/tests/stax/linear_test.py
@@ -46,7 +46,7 @@ prandom.seed(1)
 
 
 @test_utils.product(
-    same_inputs=[True, False]
+    same_inputs=[True, False],
 )
 class FlattenTest(test_utils.NeuralTangentsTestCase):
 

--- a/tests/stax/requirements_test.py
+++ b/tests/stax/requirements_test.py
@@ -50,7 +50,7 @@ prandom.seed(1)
         stax.Flatten(),
         stax.GlobalAvgPool(),
         stax.Identity()
-    ]
+    ],
 )
 class DiagonalTest(test_utils.NeuralTangentsTestCase):
 
@@ -132,7 +132,7 @@ class DiagonalClassTest(test_utils.NeuralTangentsTestCase):
 
 
 @test_utils.product(
-    same_inputs=[True, False]
+    same_inputs=[True, False],
 )
 class InputReqTest(test_utils.NeuralTangentsTestCase):
 

--- a/tests/stax/stax_test.py
+++ b/tests/stax/stax_test.py
@@ -87,14 +87,14 @@ def _get_inputs(
     key,
     same_inputs,
     shape,
-    fn=jnp.cos
-) -> tuple[jnp.ndarray, jnp.ndarray]:
+    fn=jnp.cos,
+) -> tuple[jnp.ndarray, jnp.ndarray | None]:
   key, split = random.split(key)
   x1 = fn(random.normal(key, shape))
   batch_axis = shape.index(BATCH_SIZE)
   shape = shape[:batch_axis] + (2 * BATCH_SIZE,) + shape[batch_axis + 1:]
   x2 = None if same_inputs else fn(random.normal(split, shape)) * 2
-  return x1, x2  # pytype: disable=bad-return-type  # jax-ndarray
+  return x1, x2
 
 
 def _get_net(W_std, b_std, filter_shape, is_conv, use_pooling, is_res, padding,
@@ -300,7 +300,7 @@ def _check_agreement_with_empirical(
     use_dropout,
     is_ntk,
     rtol=RTOL,
-    atol=ATOL
+    atol=ATOL,
 ):
   ((init_fn, apply_fn, kernel_fn),
    input_shape, device_count, channel_axis) = net
@@ -595,7 +595,7 @@ class StaxTest(test_utils.NeuralTangentsTestCase):
     input_size = 3
     width = 1024
 
-    # NOTE(schsam): It seems that convergence is slower when inputs are sparse.
+    # NOTE: It seems that convergence is slower when inputs are sparse.
     samples = N_SAMPLES
 
     if default_backend() == 'gpu':


### PR DESCRIPTION
Maintenance:
* Support python 3.12 and drop 3.10
* Remove obsolete type annotations
* Improve type annotations and enable pytype in more places
* Fix some deprecated calls
* Formatting
* Upgrade dependencies

Resolves https://github.com/google/neural-tangents/issues/202
